### PR TITLE
Remove z_stream from the Inflater and Deflater protocols

### DIFF
--- a/Sources/WebSocketCompression/PermessageDeflate.swift
+++ b/Sources/WebSocketCompression/PermessageDeflate.swift
@@ -35,11 +35,11 @@ public class PermessageDeflateCompressor: Deflater {
     private var stream: z_stream = z_stream()
 
     // Initialize the z_stream only once if context takeover is enabled
-    public var streamInitialized = false
+    public var initialized = false
 
     public func deflatePayload(in buffer: ByteBuffer, allocator: ByteBufferAllocator, dropFourTrailingOctets: Bool = false) -> ByteBuffer {
         // Initialize the deflater as per https://www.zlib.net/zlib_how.html
-        if noContextTakeOver || streamInitialized == false {
+        if noContextTakeOver || initialized == false {
             stream.zalloc = nil
             stream.zfree = nil
             stream.opaque = nil
@@ -49,7 +49,7 @@ public class PermessageDeflateCompressor: Deflater {
             let rc = deflateInit2_(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, -self.maxWindowBits, 8,
                                    Z_DEFAULT_STRATEGY, ZLIB_VERSION, Int32(MemoryLayout<z_stream>.size))
             precondition(rc == Z_OK, "Unexpected return from zlib init: \(rc)")
-            self.streamInitialized = true
+            self.initialized = true
         }
 
         defer {
@@ -106,7 +106,7 @@ public class PermessageDeflateDecompressor: Inflater {
     // The zlib stream
     private var stream: z_stream = z_stream()
 
-    public var streamInitialized = false
+    public var initialized = false
 
     public init (noContextTakeOver: Bool = false, maxWindowBits: Int32 = 15) {
         self.noContextTakeOver = noContextTakeOver
@@ -115,7 +115,7 @@ public class PermessageDeflateDecompressor: Inflater {
 
     public func inflatePayload(in buffer: ByteBuffer, allocator: ByteBufferAllocator) -> ByteBuffer {
         // Initialize the inflater as per https://www.zlib.net/zlib_how.html
-        if noContextTakeOver || streamInitialized == false {
+        if noContextTakeOver || initialized == false {
             stream.zalloc = nil
             stream.zfree = nil
             stream.opaque = nil
@@ -123,7 +123,7 @@ public class PermessageDeflateDecompressor: Inflater {
             stream.next_in = nil
             let rc = inflateInit2_(&stream, -self.maxWindowBits, ZLIB_VERSION, Int32(MemoryLayout<z_stream>.size))
             precondition(rc == Z_OK, "Unexpected return from zlib init: \(rc)")
-            self.streamInitialized = true
+            self.initialized = true
         }
 
         defer {

--- a/Sources/WebSocketCompression/PermessageDeflate.swift
+++ b/Sources/WebSocketCompression/PermessageDeflate.swift
@@ -90,6 +90,10 @@ public class PermessageDeflateCompressor: Deflater {
 
         return outputBuffer
     }
+
+    public func end() {
+        deflateEnd(&stream)
+    }
 }
 
 // Implementation of a deflater using zlib. This class acts like an interceptor, consuming original frames from
@@ -155,6 +159,10 @@ public class PermessageDeflateDecompressor: Inflater {
         } while stream.avail_in > 0
         return outputBuffer
     }
+
+    public func end() {
+        inflateEnd(&stream)
+    }
 }
 
 // This code is borrowed from swift-nio: https://github.com/apple/swift-nio/blob/master/Sources/NIOHTTP1/HTTPResponseCompressor.swift
@@ -192,7 +200,7 @@ private extension z_stream {
     private mutating func deflateToBuffer(buffer: inout ByteBuffer, flag: Int32) -> Int32 {
         var rc = Z_OK
 
-        buffer.writeWithUnsafeMutableBytes { outputPtr in
+        buffer.writeWithUnsafeMutableBytes(minimumWritableBytes: 0) { outputPtr in
             let typedOutputPtr = UnsafeMutableBufferPointer(start: outputPtr.baseAddress!.assumingMemoryBound(to: UInt8.self),
                                                             count: outputPtr.count)
             self.avail_out = UInt32(typedOutputPtr.count)
@@ -228,7 +236,7 @@ extension z_stream {
     private mutating func inflateToBuffer(buffer: inout ByteBuffer, flag: Int32) -> Int32 {
         var rc = Z_OK
 
-        buffer.writeWithUnsafeMutableBytes { outputPtr in
+        buffer.writeWithUnsafeMutableBytes(minimumWritableBytes: 0) { outputPtr in
             let typedOutputPtr = UnsafeMutableBufferPointer(start: outputPtr.baseAddress!.assumingMemoryBound(to: UInt8.self),
                                                             count: outputPtr.count)
             self.avail_out = UInt32(typedOutputPtr.count)

--- a/Sources/WebSocketCompression/PermessageDeflate.swift
+++ b/Sources/WebSocketCompression/PermessageDeflate.swift
@@ -32,7 +32,7 @@ public class PermessageDeflateCompressor: Deflater {
     }
 
     // The zlib stream
-    public var stream: z_stream = z_stream()
+    private var stream: z_stream = z_stream()
 
     // Initialize the z_stream only once if context takeover is enabled
     public var streamInitialized = false
@@ -104,7 +104,7 @@ public class PermessageDeflateDecompressor: Inflater {
     public var maxWindowBits:  Int32
 
     // The zlib stream
-    public var stream: z_stream = z_stream()
+    private var stream: z_stream = z_stream()
 
     public var streamInitialized = false
 

--- a/Sources/WebSocketCompression/WebSocketCompression.swift
+++ b/Sources/WebSocketCompression/WebSocketCompression.swift
@@ -25,8 +25,8 @@ public protocol Deflater {
     /// If compression context is saved, how long is the compression history window?
     var maxWindowBits: Int32 { get }
 
-    /// This is to make sure we initialize the underlying z_stream only once if context takeover is enabled
-    var streamInitialized: Bool { get set }
+    /// Indicates if the deflater is initialized 
+    var initialized: Bool { get set }
 
     /// Deflate data in the input ByteBuffer and return the compressed data in a new ByteBuffer
     func deflatePayload(in buffer: ByteBuffer, allocator: ByteBufferAllocator, dropFourTrailingOctets: Bool) -> ByteBuffer
@@ -43,8 +43,8 @@ public protocol Inflater {
     /// If compression context is saved, how long is the compression history window?
     var maxWindowBits: Int32 { get }
 
-    /// This is to make sure we initialize the z_stream only once if context takeover is enabled
-    var streamInitialized: Bool { get set }
+    /// Indicates if the inflater is initialized 
+    var initialized: Bool { get set }
 
     /// Inflate data in the input ByteBuffer and return the decompressed data in a new ByteBuffer
     func inflatePayload(in buffer: ByteBuffer, allocator: ByteBufferAllocator) -> ByteBuffer

--- a/Sources/WebSocketCompression/WebSocketCompression.swift
+++ b/Sources/WebSocketCompression/WebSocketCompression.swift
@@ -17,34 +17,38 @@
 import NIO
 import CZlib
 
-// Protocol for Deflater
-
+/// A general deflater used by the WebSocket protocol
 public protocol Deflater {
+    /// Is the compression context saved and carried over to subsequent compression operations?
     var noContextTakeOver: Bool { get }
+
+    /// If compression context is saved, how long is the compression history window?
     var maxWindowBits: Int32 { get }
 
-    // The zlib stream
-    var stream: z_stream { get set }
-
-    // Initialize the z_stream only once if context takeover is enabled
+    /// This is to make sure we initialize the underlying z_stream only once if context takeover is enabled
     var streamInitialized: Bool { get set }
 
+    /// Deflate data in the input ByteBuffer and return the compressed data in a new ByteBuffer
     func deflatePayload(in buffer: ByteBuffer, allocator: ByteBufferAllocator, dropFourTrailingOctets: Bool) -> ByteBuffer
 
+    /// Free the compression stream state
+    func end()
 }
 
-// Protocol for Deflater
-
+/// A general inflater used by the WebSocket protocol
 public protocol Inflater {
+    /// Is the compression context saved and carried over to subsequent compression operations?
     var noContextTakeOver: Bool { get }
+
+    /// If compression context is saved, how long is the compression history window?
     var maxWindowBits: Int32 { get }
 
-    // The zlib stream
-    var stream: z_stream { get set }
-
-    // Initialize the z_stream only once if context takeover is enabled
+    /// This is to make sure we initialize the z_stream only once if context takeover is enabled
     var streamInitialized: Bool { get set }
 
+    /// Inflate data in the input ByteBuffer and return the decompressed data in a new ByteBuffer
     func inflatePayload(in buffer: ByteBuffer, allocator: ByteBufferAllocator) -> ByteBuffer
 
+    /// Free the decompression stream state
+    func end()
 }

--- a/Sources/WebSocketCompression/WebSocketCompressor.swift
+++ b/Sources/WebSocketCompression/WebSocketCompressor.swift
@@ -77,7 +77,7 @@ public class WebSocketCompressor : ChannelOutboundHandler {
         // WebSocketConnection decides to close the connection, the close message
         // needs to be intercepted and the deflater closed while we're using context takeover.
         if deflater.noContextTakeOver == false {
-            deflateEnd(&deflater.stream)
+            deflater.end()
         }
         context.close(mode: mode, promise: promise)
     }

--- a/Sources/WebSocketCompression/WebSocketDecompressor.swift
+++ b/Sources/WebSocketCompression/WebSocketDecompressor.swift
@@ -52,9 +52,9 @@ public class WebSocketDecompressor : ChannelInboundHandler {
         // We should either have a data frame with rsv1 set, or a continuation frame of a compressed message. There's nothing to do otherwise.
         guard frame.isCompressedDataFrame || (frame.isContinuationFrame && self.receivingCompressedMessage) else {
             // If we are using context takeover, this is a good time to free the zstream!
-            if inflater.streamInitialized && frame.opcode == .connectionClose && !inflater.noContextTakeOver {
+            if inflater.initialized && frame.opcode == .connectionClose && !inflater.noContextTakeOver {
                 inflater.end()
-                inflater.streamInitialized = false
+                inflater.initialized = false
             }
 
             context.fireChannelRead(self.wrapInboundOut(frame))

--- a/Sources/WebSocketCompression/WebSocketDecompressor.swift
+++ b/Sources/WebSocketCompression/WebSocketDecompressor.swift
@@ -53,7 +53,7 @@ public class WebSocketDecompressor : ChannelInboundHandler {
         guard frame.isCompressedDataFrame || (frame.isContinuationFrame && self.receivingCompressedMessage) else {
             // If we are using context takeover, this is a good time to free the zstream!
             if inflater.streamInitialized && frame.opcode == .connectionClose && !inflater.noContextTakeOver {
-                deflateEnd(&inflater.stream)
+                inflater.end()
                 inflater.streamInitialized = false
             }
 


### PR DESCRIPTION
The underlying z_stream must be suitably encapsulated within the
Inflater/Deflater and need not be exposed to the users of the
latter. To enable closing this underlying z_stream, we could have
end() methods on the Inflater/Deflater.

This commit also includes some documentation improvements and a
warning is also fixed.